### PR TITLE
Add amount paid

### DIFF
--- a/db/migrations/015_add_amount_paid_to_orders.rb
+++ b/db/migrations/015_add_amount_paid_to_orders.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+
+  up do
+    add_column :orders, :amount_paid, :bignum
+  end
+
+  down do
+    drop_column :orders, :amount_paid
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,9 @@ Sequel.migration do
       String :description, :size=>255
       Integer :reused, :default=>0
       String :callback_data, :size=>255
+      String :amount_paid
+      String :callback_url, :size=>255
+      String :title, :size=>255
       
       index [:address]
       index [:id], :unique=>true

--- a/spec/lib/gateway_spec.rb
+++ b/spec/lib/gateway_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe StraightServer::Gateway do
     @order_mock = double("order mock")
     allow(@order_mock).to receive(:old_status)
     allow(@order_mock).to receive(:description=)
+    allow(@order_mock).to receive(:set_amount_paid)
     allow(@order_mock).to receive(:reused).and_return(0)
     [:id, :gateway=, :save, :to_h, :id=].each { |m| allow(@order_mock).to receive(m) }
     @new_order_args = { amount: 1, keychain_id: 1, currency: nil, btc_denomination: nil }

--- a/straight-server.gemspec
+++ b/straight-server.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
     "db/migrations/011_add_callback_data_to_orders.rb",
     "db/migrations/012_add_address_provider.rb",
     "db/migrations/013_add_address_derivation_scheme.rb",
+    "db/migrations/015_add_amoun_paid_to_orders.rb",
     "db/schema.rb",
     "examples/client/client.dart",
     "examples/client/client.html",


### PR DESCRIPTION
In `#set_amount_paid` check for nil only for happy tests. Not happy with it. Catch `nil` error pointless there in my opinion, because any communication problems will be caught at the lower levels. But better not trust to any external services (they can return anything) at all and check the return value too. 

And I think it's better to make more explicit checking for Order changes. It's too much functions for `#status` methods, that not related to them directly.